### PR TITLE
Update etherscan.py

### DIFF
--- a/etherscan/etherscan.py
+++ b/etherscan/etherscan.py
@@ -43,7 +43,7 @@ class Client():
     @property
     def session(self):
         if not self._session:
-            self._session = requests_cache.core.CachedSession(
+            self._session = requests_cache.CachedSession(
                 cache_name=self._cache_name,
                 backend=self._cache_backend,
                 expire_after=self._cache_expire_after,


### PR DESCRIPTION
removing core from requests_cache.core.CachedSession.. on line 46. This is because requests_cache,core is deprecated as per the core.py file in the requests_cache package.